### PR TITLE
Docker Compose 2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,6 @@ The default cookbook installs docker, makes sure the docker service is running.
 
 This is just a wrapper cookbook for [docker][docker-github]
 
-## Requirements
-
-### Supported Platforms
-
-- Debian Buster
-
-### Chef
-
-- Chef 13.1+
-
-### Cookbook Depdendencies
-
-- [docker][docker-github]
-
 ## Usage
 
 Add the cookbook to your Berksfile:
@@ -62,6 +48,7 @@ Installs docker-compose as a docker image using the run script wrapper from dock
 
 #### Actions
 - `install`: Installs docker-compose and bash completion
+- `uninstall`: Uninstalls docker-compose and bash completion
 
 #### Properties
 - `version`: The desired version as string, defaults to `'latest'`

--- a/README.md
+++ b/README.md
@@ -43,8 +43,34 @@ codenamephp_docker_service 'Install docker' do
 end
 ```
 
+### Compose2
+Installs docker compose cli plugin.
+
+#### Actions
+- `install`: Installs docker-compose and bash completion
+
+#### Properties
+- `version`: The desired version as string, defaults to `'latest'`
+
+#### Examples
+With minimal properties:
+```ruby
+# Install
+codenamephp_docker_compose2 'Install docker-compose'
+```
+
+With custom version:
+```ruby
+codenamephp_docker_compose2 'Install docker-compose' do
+  version '2.0.1'
+end
+```
+
 ### Compose
-Installs docker-compose as a docker image using the run script wrapper from docker-compose github. The bash completion is also installed.
+Installs docker-compose (v1) as a docker image using the run script wrapper from docker-compose github. The bash completion is also installed.
+
+#### Deprecated
+This resource has been deprecated and will be removed with the next major release. Use the `codenamephp_docker_compose2` resource instead.
 
 #### Actions
 - `install`: Installs docker-compose and bash completion

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -2,6 +2,14 @@ driver:
   name: dokken
   chef_version: current
   privileged: true # because Docker and SystemD/Upstart
+  volumes:
+    # saves the apt archieves outside of the container
+    - /var/cache/apt/archives/:/var/cache/apt/archives/
+    - '/var/lib/docker'
+  intermediate_instructions:
+    # prevent APT from deleting the APT folder
+    - RUN rm /etc/apt/apt.conf.d/docker-clean
+    - RUN /usr/bin/apt-get update
 
 transport:
   name: dokken
@@ -15,4 +23,8 @@ platforms:
   - name: debian-10
     driver:
       image: dokken/debian-10
+      pid_one_command: /bin/systemd
+  - name: debian-11
+    driver:
+      image: dokken/debian-11
       pid_one_command: /bin/systemd

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -15,8 +15,19 @@ platforms:
 suites:
   - name: default
     run_list:
-      - recipe[test]
+      - recipe[test::default]
+      - recipe[test::compose2]
     verifier:
       inspec_tests:
         - test/integration/default
+        - test/integration/compose2
+    attributes:
+  - name: compose1
+    run_list:
+      - recipe[test::default]
+      - recipe[test::compose1]
+    verifier:
+      inspec_tests:
+        - test/integration/default
+        - test/integration/compose1
     attributes:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -10,6 +10,7 @@ verifier:
 
 platforms:
   - name: debian-10
+  - name: debian-11
 
 suites:
   - name: default

--- a/resources/compose.rb
+++ b/resources/compose.rb
@@ -2,6 +2,8 @@
 
 unified_mode true
 
+deprecated 'The codenamephp_docker_compose resource is deprecated since doocker compose is now a part of the Docker CLI. Use the codenamephp_docker_compose2 resource instead.'
+
 property :version, String, default: '1.29.2', description: 'The version of docker-compose to install, defaults to "latest"'
 
 action :install do
@@ -39,7 +41,7 @@ action_class do
     arch = shell_out('uname -m').stdout.strip
     file = "docker-compose-#{distro}-#{arch}"
 
-    new_resource.version == 'latest' ? "https://github.com/docker/compose/releases/latest/download/#{file}" : "https://github.com/docker/compose/releases/download/#{new_resource.version}/#{file}"
+    "https://github.com/docker/compose/releases/download/#{new_resource.version}/#{file}"
   end
 
   def compose_bash_completion_url

--- a/resources/compose.rb
+++ b/resources/compose.rb
@@ -35,6 +35,16 @@ action :install do
   end
 end
 
+action :uninstall do
+  file '/user/local/bin/docker-compose' do
+    action :delete
+  end
+
+  file '/etc/bash_completion.d/docker-compose' do
+    action :delete
+  end
+end
+
 action_class do
   def compose_url
     distro = shell_out('uname -s').stdout.strip

--- a/resources/compose.rb
+++ b/resources/compose.rb
@@ -2,7 +2,7 @@
 
 unified_mode true
 
-property :version, String, default: 'latest', description: 'The version of docker-compose to install, defaults to "latest"'
+property :version, String, default: '1.29.2', description: 'The version of docker-compose to install, defaults to "latest"'
 
 action :install do
   remote_file 'download docker-compose' do

--- a/resources/compose2.rb
+++ b/resources/compose2.rb
@@ -1,0 +1,30 @@
+unified_mode true
+
+property :version, String, default: 'latest', description: 'The version of docker compose to install, defaults to "latest"'
+
+action :install do
+  directory '/usr/local/lib/docker/cli-plugins' do
+    recursive true
+    owner 'root'
+    group 'root'
+  end
+
+  remote_file 'download docker compose' do
+    source compose_url
+    path '/usr/local/lib/docker/cli-plugins/docker-compose'
+    owner 'root'
+    group 'root'
+    mode '0755'
+    action :create
+  end
+end
+
+action_class do
+  def compose_url
+    distro = shell_out('uname -s').stdout.strip
+    arch = shell_out('uname -m').stdout.strip
+    file = "docker-compose-#{distro}-#{arch}"
+
+    new_resource.version == 'latest' ? "https://github.com/docker/compose/releases/latest/download/#{file}" : "https://github.com/docker/compose/releases/download/#{new_resource.version}/#{file}"
+  end
+end

--- a/spec/unit/resources/compose2_spec.rb
+++ b/spec/unit/resources/compose2_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe 'codenamephp_docker::compose' do
+  platform 'debian' # https://github.com/chefspec/chefspec/issues/953
+
+  step_into :codenamephp_docker_compose2
+
+  stubs_for_provider('codenamephp_docker_compose2[Install docker compose]') do |provider|
+    allow(provider).to receive_shell_out()
+    allow(provider).to receive_shell_out('uname -s', stdout: 'somedist')
+    allow(provider).to receive_shell_out('uname -m', stdout: 'somearch')
+    allow(provider).to receive_shell_out("docker-compose -v | grep version | awk -F'[ ,]+' '{print $3}'", stdout: 'someversion')
+  end
+
+  context 'When all attributes are default' do
+    recipe do
+      codenamephp_docker_compose2 'Install docker compose'
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+
+    it 'downloads docker compose' do
+      expect(chef_run).to create_remote_file('download docker compose').with(
+        source: 'https://github.com/docker/compose/releases/latest/download/docker-compose-somedist-somearch',
+        path: '/usr/local/lib/docker/cli-plugins/docker-compose',
+        owner: 'root',
+        group: 'root',
+        mode: '0755'
+      )
+    end
+  end
+
+  context 'With custom version' do
+    recipe do
+      codenamephp_docker_compose2 'Install docker compose' do
+        version 'someversion'
+      end
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+
+    it 'downloads docker compose' do
+      expect(chef_run).to create_remote_file('download docker compose').with(
+        source: 'https://github.com/docker/compose/releases/download/someversion/docker-compose-somedist-somearch',
+        path: '/usr/local/lib/docker/cli-plugins/docker-compose',
+        owner: 'root',
+        group: 'root',
+        mode: '0755'
+      )
+    end
+  end
+end

--- a/spec/unit/resources/compose_spec.rb
+++ b/spec/unit/resources/compose_spec.rb
@@ -31,7 +31,7 @@ describe 'codenamephp_docker::compose' do
 
     it 'downloads docker-compose' do
       expect(chef_run).to create_remote_file('download docker-compose').with(
-        source: 'https://github.com/docker/compose/releases/latest/download/docker-compose-somedist-somearch',
+        source: 'https://github.com/docker/compose/releases/download/1.29.2/docker-compose-somedist-somearch',
         path: '/usr/local/bin/docker-compose',
         owner: 'root',
         group: 'root',
@@ -53,28 +53,6 @@ describe 'codenamephp_docker::compose' do
       expect(chef_run).to create_remote_file('download bash completion').with(
         source: 'https://raw.githubusercontent.com/docker/compose/someversion/contrib/completion/bash/docker-compose',
         path: '/etc/bash_completion.d/docker-compose',
-        owner: 'root',
-        group: 'root',
-        mode: '0755'
-      )
-    end
-  end
-
-  context 'With custom version' do
-    recipe do
-      codenamephp_docker_compose 'Install docker-compose' do
-        version 'someversion'
-      end
-    end
-
-    it 'converges successfully' do
-      expect { chef_run }.to_not raise_error
-    end
-
-    it 'downloads docker-compose' do
-      expect(chef_run).to create_remote_file('download docker-compose').with(
-        source: 'https://github.com/docker/compose/releases/download/someversion/docker-compose-somedist-somearch',
-        path: '/usr/local/bin/docker-compose',
         owner: 'root',
         group: 'root',
         mode: '0755'

--- a/spec/unit/resources/compose_spec.rb
+++ b/spec/unit/resources/compose_spec.rb
@@ -23,6 +23,9 @@ describe 'codenamephp_docker::compose' do
   context 'When all attributes are default' do
     recipe do
       codenamephp_docker_compose 'Install docker-compose'
+      codenamephp_docker_compose 'Uninstall docker-compose' do
+        action :uninstall
+      end
     end
 
     it 'converges successfully' do
@@ -57,6 +60,11 @@ describe 'codenamephp_docker::compose' do
         group: 'root',
         mode: '0755'
       )
+    end
+
+    it 'deletes the bash completion and docker-compose binary' do
+      expect(chef_run).to delete_file('/user/local/bin/docker-compose')
+      expect(chef_run).to delete_file('/etc/bash_completion.d/docker-compose')
     end
   end
 end

--- a/test/fixtures/cookbooks/test/recipes/compose1.rb
+++ b/test/fixtures/cookbooks/test/recipes/compose1.rb
@@ -1,0 +1,1 @@
+codenamephp_docker_compose 'Install docker-compose'

--- a/test/fixtures/cookbooks/test/recipes/compose2.rb
+++ b/test/fixtures/cookbooks/test/recipes/compose2.rb
@@ -1,0 +1,1 @@
+codenamephp_docker_compose2 'Install docker compose'

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -1,5 +1,3 @@
 # frozen_string_literal: true
 
 codenamephp_docker_service 'Install docker'
-
-codenamephp_docker_compose 'Install docker-compose'

--- a/test/integration/compose1/compose_test.rb
+++ b/test/integration/compose1/compose_test.rb
@@ -3,3 +3,7 @@
 describe command('docker-compose -v') do
   its('stdout') { should match(/docker-compose version/) }
 end
+
+describe command("docker-compose -v | grep version | awk -F'[ ,]+' '{print $3}'") do
+  its('stdout') { should cmp < '2.0.0' }
+end

--- a/test/integration/compose2/compose_test.rb
+++ b/test/integration/compose2/compose_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+describe command('docker compose version') do
+  its('stdout') { should match(/Docker Compose version/) }
+end
+
+describe command("docker compose version | grep version | awk -F'[ ,]+' '{print $4}'") do
+  its('stdout') { should cmp > '2.0.0' }
+end


### PR DESCRIPTION
Docker compose 2 was release which is now part of the Docker CLI as a plugin. The install is slightly different so a new resource was created and the compose resource is now deprecated.

In addition, the default version for the old compose resource is not "latest" anymore since this would install v2 but 1.29.2 which is the latest v1. version at the time of writing.